### PR TITLE
Fix autogenerated CloudFormation resource names to be deterministic (…

### DIFF
--- a/infra/main/java/com/antonycc/oidc/OidcEndpointFunction.java
+++ b/infra/main/java/com/antonycc/oidc/OidcEndpointFunction.java
@@ -11,6 +11,8 @@ import software.amazon.awscdk.services.cloudfront.ResponseHeadersPolicy;
 import software.amazon.awscdk.services.cloudfront.ViewerProtocolPolicy;
 import software.amazon.awscdk.services.cloudfront.origins.HttpOrigin;
 import software.amazon.awscdk.services.iam.ManagedPolicy;
+import software.amazon.awscdk.services.iam.Role;
+import software.amazon.awscdk.services.iam.ServicePrincipal;
 import software.amazon.awscdk.services.lambda.AssetImageCodeProps;
 import software.amazon.awscdk.services.lambda.DockerImageCode;
 import software.amazon.awscdk.services.lambda.DockerImageFunction;
@@ -24,6 +26,7 @@ import software.amazon.awscdk.services.logs.RetentionDays;
 import software.constructs.Construct;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -34,6 +37,7 @@ import java.util.Objects;
 public class OidcEndpointFunction extends Construct {
   // Exposed created resources/objects
   public final LogGroup logGroup;
+  public final Role functionRole;
   public final DockerImageFunction function;
   public final FunctionUrl functionUrl;
   public final HttpOrigin httpOrigin;
@@ -50,6 +54,17 @@ public class OidcEndpointFunction extends Construct {
         .logGroupName("/aws/lambda/" + props.functionName)
         .removalPolicy(RemovalPolicy.DESTROY)
         .retention(RetentionDays.ONE_WEEK)
+        .build();
+
+    // IAM role for the Lambda function with deterministic name
+    this.functionRole = Role.Builder.create(this, props.functionName + "-ServiceRole")
+        .roleName(props.functionName + "-service-role")
+        .assumedBy(new ServicePrincipal("lambda.amazonaws.com"))
+        .managedPolicies(List.of(
+            ManagedPolicy.fromAwsManagedPolicyName("service-role/AWSLambdaBasicExecutionRole"),
+            ManagedPolicy.fromAwsManagedPolicyName("AWSXRayDaemonWriteAccess"),
+            ManagedPolicy.fromAwsManagedPolicyName("CloudWatchLambdaApplicationSignalsExecutionRolePolicy")
+        ))
         .build();
 
     // Build args are constant currently but can be extended later
@@ -84,11 +99,8 @@ public class OidcEndpointFunction extends Construct {
         .timeout(Duration.seconds(15))
         .tracing(Tracing.ACTIVE)
         .logGroup(this.logGroup)
+        .role(this.functionRole)
         .build();
-
-      var managedPolicy = ManagedPolicy.fromAwsManagedPolicyName("CloudWatchLambdaApplicationSignalsExecutionRolePolicy");
-      var functionRole = Objects.requireNonNull(this.function.getRole());
-      functionRole.addManagedPolicy(managedPolicy);
 
       this.functionUrl = this.function.addFunctionUrl(FunctionUrlOptions.builder()
         .authType(FunctionUrlAuthType.NONE)

--- a/infra/main/java/com/antonycc/oidc/OidcProviderStack.java
+++ b/infra/main/java/com/antonycc/oidc/OidcProviderStack.java
@@ -329,7 +329,7 @@ public class OidcProviderStack extends Stack {
             .sslSupportMethod(SSLMethod.SNI)
             .build();
 
-    // Grant CloudFront access to the origin lambdas
+    // Grant CloudFront access to the origin lambdas with compressed names
     Permission invokeFunctionUrlPermission =
         Permission.builder()
             .principal(new ServicePrincipal("cloudfront.amazonaws.com"))
@@ -337,10 +337,9 @@ public class OidcProviderStack extends Stack {
             .functionUrlAuthType(FunctionUrlAuthType.NONE)
             .sourceArn(this.distribution.getDistributionArn())
             .build();
-    this.authorizeEndpoint.function.addPermission("AuthLambdaAllowCloudFrontInvoke", invokeFunctionUrlPermission);
-    this.tokenEndpoint.function.addPermission("TokenLambdaAllowCloudFrontInvoke", invokeFunctionUrlPermission);
-    this.userinfoEndpoint.function.addPermission(
-        "UserInfoLambdaAllowCloudFrontInvoke", invokeFunctionUrlPermission);
+    this.authorizeEndpoint.function.addPermission(compressedResourceNamePrefix + "-cf-auth", invokeFunctionUrlPermission);
+    this.tokenEndpoint.function.addPermission(compressedResourceNamePrefix + "-cf-token", invokeFunctionUrlPermission);
+    this.userinfoEndpoint.function.addPermission(compressedResourceNamePrefix + "-cf-userinfo", invokeFunctionUrlPermission);
 
     this.bucketDeploymentLogGroup =
         LogGroup.Builder.create(this, resourceNamePrefix + "-BucketDeploymentLogGroup")


### PR DESCRIPTION
…#53)

* Initial plan

* Add deterministic IAM roles and shorter CloudFront permissions for Lambda functions



* Update infra/main/java/com/antonycc/oidc/OidcEndpointFunction.java



* Update infra/main/java/com/antonycc/oidc/OidcEndpointFunction.java



* Update infra/main/java/com/antonycc/oidc/OidcEndpointFunction.java



---------